### PR TITLE
Auto match and concatenate biography fields

### DIFF
--- a/API_EXAMPLE.md
+++ b/API_EXAMPLE.md
@@ -163,3 +163,132 @@ curl -X POST https://your-api.com/world-data \\n  -H \"Content-Type: application
 ```
 
 This should help you get started with building an API that works with the Archivist Sync module!
+
+## Enhanced Biography Field Processing
+
+The module now includes advanced biography field auto-matching and concatenation functionality. This allows for intelligent processing of character biographical information across multiple fields.
+
+### Biography Field Discovery
+
+The system automatically discovers biography-related fields in actor data, including:
+
+- **Core Biography**: `biography`, `bio`, `backstory`, `appearance`
+- **Personality**: `beliefs`, `catchphrases`, `dislikes`, `likes`, `attitude`
+- **Relationships**: `allies`, `enemies`, `organizations`, `family`, `mentor`, `rival`
+- **Background**: `birthplace`, `campaignnotes`, `personality`, `traits`, `background`
+- **History**: `history`, `origin`, `motivation`, `goals`, `fears`, `secrets`
+
+### Usage Examples
+
+```javascript
+// Import the enhanced field mapper functions
+import { 
+    processBiographyFields, 
+    discoverBiographyFields,
+    concatenateBiographyFields,
+    writeBestBiographyEnhanced 
+} from './scripts/modules/field-mapper.js';
+
+// Example 1: Auto-discover and process all biography fields
+const actor = game.actors.getName("Aragorn");
+const result = processBiographyFields(actor, {
+    includeFieldLabels: true,    // Add field names as headers
+    preserveVisibility: true,    // Respect visibility settings
+    convertToMarkdown: true      // Convert final HTML to markdown
+});
+
+console.log("Concatenated HTML:", result.html);
+console.log("Markdown version:", result.markdown);
+console.log("Discovered fields:", result.fields);
+
+// Example 2: Just discover fields without processing
+const biographyFields = discoverBiographyFields(actor);
+biographyFields.forEach(field => {
+    console.log(`${field.field}: ${field.value.substring(0, 50)}...`);
+});
+
+// Example 3: Enhanced writing with auto-processing
+await writeBestBiographyEnhanced(actor, {
+    includeFieldLabels: false,
+    preserveVisibility: true,
+    convertToMarkdown: true
+});
+
+// Example 4: Custom concatenation with specific options
+const html = concatenateBiographyFields(biographyFields, {
+    includeFieldLabels: true,
+    preserveVisibility: false,  // Include hidden fields
+    actor: actor
+});
+```
+
+### Field Priority and Sorting
+
+Fields are automatically sorted by priority:
+
+1. **High Priority** (1000): `biography`, `bio`
+2. **Very High** (900): `backstory`
+3. **High** (800): `appearance`
+4. **Medium-High** (700): `description`
+5. **Medium** (600): `personality`
+6. **Medium-Low** (500): `traits`
+7. **Low** (400): `background`
+8. **Very Low** (300): `history`
+9. **Minimal** (200): `notes`
+10. **Minimal** (100): `summary`
+
+### Visibility Handling
+
+The system respects Foundry's visibility settings when `preserveVisibility: true`:
+
+```javascript
+// Example actor with visibility settings
+const actor = {
+    system: {
+        details: {
+            biography: {
+                value: "Public biography text",
+                visibility: {
+                    appearance: true,    // Visible
+                    backstory: false     // Hidden
+                }
+            }
+        }
+    }
+};
+
+// Only visible fields will be included
+const result = processBiographyFields(actor, {
+    preserveVisibility: true
+});
+```
+
+### HTML to Markdown Conversion
+
+The system automatically converts HTML content to clean markdown:
+
+```html
+<!-- Input HTML -->
+<h4>Appearance</h4>
+<p>Tall and <strong>noble</strong> with <em>piercing</em> eyes</p>
+
+<!-- Output Markdown -->
+## Appearance
+
+Tall and **noble** with _piercing_ eyes
+```
+
+### Integration with Existing Systems
+
+This enhanced functionality is backward compatible with existing biography writing functions:
+
+```javascript
+// Original function still works
+await writeBestBiography(actor, "<p>Simple biography text</p>");
+
+// New enhanced function with auto-processing
+await writeBestBiographyEnhanced(actor, {
+    includeFieldLabels: true,
+    preserveVisibility: true
+});
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Enhanced Biography Field Processing**: Auto-discovery and concatenation of biography-related fields
+- **Biography Field Auto-Matching**: Intelligent detection of biographical information across multiple actor fields
+- **HTML to Markdown Conversion**: Automatic conversion of concatenated biography HTML to clean markdown
+- **Field Priority Sorting**: Smart ordering of biography fields by importance and relevance
+- **Visibility Awareness**: Respect for Foundry's field visibility settings during processing
+- **New Functions**: 
+  - `discoverBiographyFields()` - Auto-discover biography fields in actor data
+  - `concatenateBiographyFields()` - Concatenate fields into structured HTML
+  - `processBiographyFields()` - Complete processing pipeline with markdown conversion
+  - `writeBestBiographyEnhanced()` - Enhanced biography writing with auto-processing
+- **Comprehensive Documentation**: Added usage examples and API documentation for new features
+- **Backward Compatibility**: All new features work alongside existing biography functions
+
+### Enhanced
+- **Field Mapper Module**: Significantly expanded with biography field intelligence
+- **Documentation**: Added detailed examples and usage patterns in API_EXAMPLE.md
+- **Field Discovery**: Supports 20+ biography-related field types including appearance, backstory, allies, enemies, beliefs, etc.
+
+### Technical Details
+- Maintains full backward compatibility with existing `writeBestBiography()` function
+- Integrates with existing HTML to markdown conversion utilities
+- Uses semantic field matching for intelligent biography field detection
+- Supports nested object scanning for complex actor data structures
+
 ## [1.0.0] - 2024-08-31
 
 ### Added

--- a/scripts/modules/field-mapper.js
+++ b/scripts/modules/field-mapper.js
@@ -1,9 +1,38 @@
 /**
  * Field mapping utilities to probe Foundry documents for the best schema fields.
  * Deterministic heuristics first; optional semantic fallback when enabled.
+ * 
+ * NEW: Enhanced biography field support with auto-matching and concatenation:
+ * 
+ * Example usage:
+ * ```javascript
+ * // Auto-discover and concatenate all biography fields from an actor
+ * const result = processBiographyFields(actor, {
+ *     includeFieldLabels: true,    // Add field names as headers
+ *     preserveVisibility: true,    // Respect visibility settings
+ *     convertToMarkdown: true      // Convert final HTML to markdown
+ * });
+ * 
+ * console.log(result.html);        // Concatenated HTML with all biography fields
+ * console.log(result.markdown);    // Markdown version
+ * console.log(result.fields);      // Array of discovered fields
+ * 
+ * // Enhanced writing with auto-processing
+ * await writeBestBiographyEnhanced(actor, {
+ *     includeFieldLabels: false,
+ *     preserveVisibility: true,
+ *     convertToMarkdown: true
+ * });
+ * ```
+ * 
+ * The system automatically discovers fields like:
+ * - appearance, backstory, allies, enemies, beliefs
+ * - catchphrases, dislikes, likes, organizations
+ * - anathema, edicts, attitude, birthplace, etc.
  */
 
 import { suggestBestStringPath, discoverStringPaths } from './semantic-mapper.js';
+import { htmlToMarkdown } from './importer-normalizer.js';
 
 /**
  * Try to write an HTML biography string to the best-matching field on an Actor.
@@ -216,6 +245,184 @@ export async function writeBestJournalDescription(journal, htmlString) {
         return;
     }
     await journal.update({ content: safe });
+}
+
+/**
+ * Discover all biography-related fields in an actor's system data.
+ * Looks for fields that contain biographical information like appearance, backstory, etc.
+ * @param {Actor} actor
+ * @returns {Array<{path: string, value: string, field: string}>}
+ */
+export function discoverBiographyFields(actor) {
+    const biographyFields = [];
+    const biographyKeywords = [
+        'biography', 'bio', 'backstory', 'appearance', 'description', 'notes', 'summary',
+        'allies', 'enemies', 'beliefs', 'catchphrases', 'dislikes', 'likes', 'organizations',
+        'anathema', 'edicts', 'attitude', 'birthplace', 'campaignnotes', 'personality',
+        'traits', 'background', 'history', 'origin', 'motivation', 'goals', 'fears',
+        'secrets', 'relationships', 'family', 'mentor', 'rival', 'companion'
+    ];
+
+    const scan = (obj, path = []) => {
+        if (!obj || typeof obj !== 'object') return;
+        
+        for (const [key, value] of Object.entries(obj)) {
+            const currentPath = [...path, key];
+            const pathString = currentPath.join('.');
+            
+            // Check if this field matches biography keywords
+            const isBiographyField = biographyKeywords.some(keyword => 
+                key.toLowerCase().includes(keyword.toLowerCase())
+            );
+            
+            if (typeof value === 'string' && value.trim() && isBiographyField) {
+                biographyFields.push({
+                    path: 'system.' + pathString,
+                    value: value.trim(),
+                    field: key
+                });
+            } else if (value && typeof value === 'object' && currentPath.length < 6) {
+                // Recursively scan nested objects
+                scan(value, currentPath);
+            }
+        }
+    };
+
+    scan(actor.system);
+    return biographyFields;
+}
+
+/**
+ * Concatenate all discovered biography fields into a single HTML string.
+ * @param {Array<{path: string, value: string, field: string}>} biographyFields
+ * @param {Object} options - Configuration options
+ * @param {boolean} options.includeFieldLabels - Whether to include field names as headers
+ * @param {boolean} options.preserveVisibility - Whether to respect visibility settings
+ * @param {Actor} options.actor - Actor reference for visibility checks
+ * @returns {string} Concatenated HTML string
+ */
+export function concatenateBiographyFields(biographyFields, options = {}) {
+    const { includeFieldLabels = true, preserveVisibility = true, actor = null } = options;
+    const htmlParts = [];
+
+    // Sort fields by priority/importance
+    const fieldPriority = {
+        'biography': 1000, 'bio': 1000, 'backstory': 900, 'appearance': 800,
+        'description': 700, 'personality': 600, 'traits': 500, 'background': 400,
+        'history': 300, 'notes': 200, 'summary': 100
+    };
+
+    const sortedFields = biographyFields.sort((a, b) => {
+        const aPriority = fieldPriority[a.field.toLowerCase()] || 0;
+        const bPriority = fieldPriority[b.field.toLowerCase()] || 0;
+        return bPriority - aPriority;
+    });
+
+    for (const field of sortedFields) {
+        // Check visibility if actor is provided and preserveVisibility is true
+        if (preserveVisibility && actor) {
+            const visibilityPath = field.path.replace(/\.(value|public)$/, '.visibility');
+            const visibility = foundry.utils.getProperty(actor, visibilityPath);
+            if (visibility && typeof visibility === 'object') {
+                const fieldName = field.field.toLowerCase();
+                if (visibility[fieldName] === false) {
+                    continue; // Skip hidden fields
+                }
+            }
+        }
+
+        const fieldValue = field.value.trim();
+        if (!fieldValue) continue;
+
+        // Clean up the field name for display
+        const displayName = field.field
+            .replace(/([A-Z])/g, ' $1') // Add spaces before capitals
+            .replace(/^./, str => str.toUpperCase()) // Capitalize first letter
+            .replace(/_(.)/g, (_, char) => ' ' + char.toUpperCase()); // Handle underscores
+
+        if (includeFieldLabels) {
+            htmlParts.push(`<h4>${displayName}</h4>`);
+        }
+        
+        // Wrap content in paragraph if it's not already HTML
+        if (!fieldValue.includes('<') && !fieldValue.includes('>')) {
+            htmlParts.push(`<p>${fieldValue}</p>`);
+        } else {
+            htmlParts.push(fieldValue);
+        }
+    }
+
+    return htmlParts.join('\n\n');
+}
+
+/**
+ * Auto-match and concatenate biography fields from an actor, then process as markdown.
+ * This is the main function that combines discovery, concatenation, and markdown conversion.
+ * @param {Actor} actor
+ * @param {Object} options - Configuration options
+ * @param {boolean} options.includeFieldLabels - Whether to include field names as headers
+ * @param {boolean} options.preserveVisibility - Whether to respect visibility settings
+ * @param {boolean} options.convertToMarkdown - Whether to convert final HTML to markdown
+ * @returns {{html: string, markdown: string, fields: Array}} Result object with HTML, markdown, and field info
+ */
+export function processBiographyFields(actor, options = {}) {
+    const { 
+        includeFieldLabels = true, 
+        preserveVisibility = true, 
+        convertToMarkdown = true 
+    } = options;
+
+    // Discover all biography fields
+    const biographyFields = discoverBiographyFields(actor);
+    
+    if (biographyFields.length === 0) {
+        return { html: '', markdown: '', fields: [] };
+    }
+
+    // Concatenate into HTML
+    const html = concatenateBiographyFields(biographyFields, {
+        includeFieldLabels,
+        preserveVisibility,
+        actor
+    });
+
+    // Convert to markdown if requested
+    const markdown = convertToMarkdown ? htmlToMarkdown(html) : '';
+
+    return {
+        html,
+        markdown,
+        fields: biographyFields
+    };
+}
+
+/**
+ * Enhanced version of writeBestBiography that can concatenate multiple biography fields.
+ * @param {Actor} actor
+ * @param {string|Object} input - HTML string or options object for auto-processing
+ * @param {Object} options - Configuration options
+ * @returns {Promise<{ok: boolean, path?: string, pathTried?: string[], processed?: Object}>}
+ */
+export async function writeBestBiographyEnhanced(actor, input, options = {}) {
+    // If input is a string, use the original function
+    if (typeof input === 'string') {
+        return await writeBestBiography(actor, input);
+    }
+
+    // If input is an options object, process biography fields automatically
+    const processed = processBiographyFields(actor, input);
+    
+    if (!processed.html) {
+        return { ok: false, pathTried: [], processed };
+    }
+
+    // Write the concatenated HTML using the original function
+    const result = await writeBestBiography(actor, processed.html);
+    
+    return {
+        ...result,
+        processed
+    };
 }
 
 


### PR DESCRIPTION
Add auto-matching and concatenation for multiple biography fields to `field-mapper.js` to support richer, markdown-processed character biographies.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f1b93ec-5cbb-44d6-af86-c36e18bb15bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f1b93ec-5cbb-44d6-af86-c36e18bb15bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

