### PR TITLE
CI: add a v14 stable publish track, guard both against publishing the wrong version line

### DIFF
--- a/.github/RELEASE_WORKFLOW.md
+++ b/.github/RELEASE_WORKFLOW.md
@@ -1,8 +1,26 @@
 # Release Workflow Documentation
 
-This module uses two separate GitHub Actions workflows for releases:
+This module publishes **two parallel version lines to the same Foundry package
+listing**: a legacy v13 line (`1.x`, from `main`) and a v14 line (`2.x`, from
+`release/v14`). Foundry's registry natively supports multiple versions per
+package, each with its own compatibility range — the Foundry client picks
+whichever version matches the user's installed core version, so no separate
+listing/package id is needed.
 
-## 🚀 Production Release (main branch)
+There are four GitHub Actions workflows involved:
+
+| Branch | Workflow | Publishes to Foundry? | Version family |
+|---|---|---|---|
+| `main` | `auto-release.yml` | Yes | `1.x`, compat `13.x` |
+| `release/v14` | `auto-release-v14.yml` | Yes | `2.x`, compat `14.x` |
+| `staging` | `beta-release.yml` | No (GitHub pre-release only) | v14 betas |
+
+Both stable workflows refuse to run if `module.json`'s version/compatibility
+don't match their expected family — this guards against the exact incident
+that previously broke v13 users (a v14-shaped build publishing under a v13
+version string via `main`).
+
+## 🚀 Production Release — v13 (main branch)
 
 **Workflow:** `.github/workflows/auto-release.yml`
 
@@ -10,14 +28,16 @@ This module uses two separate GitHub Actions workflows for releases:
 - Automatically triggered when `module.json` or `package.json` is pushed to the `main` branch
 
 ### What it does:
-1. ✅ Verifies version consistency between `module.json` and `package.json`
-2. ✅ Checks that `CHANGELOG.md` has been updated for the new version
-3. ✅ Creates a GitHub release with tag `vX.Y.Z`
-4. ✅ Uploads `module.zip` and `module.json` as release assets
-5. ✅ **Publishes to Foundry VTT package repository** (visible to all users)
+1. ✅ Verifies `module.json` version is `1.x` and `compatibility.minimum` is `13.x` — refuses to publish otherwise
+2. ✅ Verifies version consistency between `module.json` and `package.json`
+3. ✅ Checks that `CHANGELOG.md` has been updated for the new version
+4. ✅ Creates a GitHub release with tag `vX.Y.Z`
+5. ✅ Updates the moving `v13-latest` tag/release so direct-manifest-URL installs auto-update
+6. ✅ Uploads `module.zip` and `module.json` as release assets
+7. ✅ **Publishes to Foundry VTT package repository** (visible to all users)
 
 ### How to create a production release:
-1. Update version in both `module.json` and `package.json`
+1. Update version in both `module.json` and `package.json` (keep it in the `1.x` family)
 2. Add a section for the new version in `CHANGELOG.md`:
    ```markdown
    ## [1.2.0] - 2025-01-15
@@ -26,6 +46,29 @@ This module uses two separate GitHub Actions workflows for releases:
    ```
 3. Commit and push to `main`
 4. The workflow will automatically create the release
+
+---
+
+## 🚀 Production Release — v14 (release/v14 branch)
+
+**Workflow:** `.github/workflows/auto-release-v14.yml`
+
+### When it runs:
+- Automatically triggered when `module.json` or `package.json` is pushed to the `release/v14` branch
+
+### What it does:
+Same steps as the v13 workflow above, but requires `module.json` version to be
+`2.x` and `compatibility.minimum` to be `14.x`, and maintains its own moving
+`v14-latest` tag/release instead of `v13-latest`. Publishes to the **same**
+Foundry package listing as `main` (same `FOUNDRY_ADMIN_MODULE_ID`), as a
+separate version entry with its own compatibility range.
+
+### How to create a v14 production release:
+1. Merge tested `staging` work into `release/v14` (create the branch from
+   `staging` if it doesn't exist yet)
+2. Update version in both `module.json` and `package.json` (keep it in the `2.x` family, compat `14.x`)
+3. Add a section for the new version in `CHANGELOG.md`
+4. Push to `release/v14` — the workflow creates the release and publishes to Foundry
 
 ---
 
@@ -77,28 +120,40 @@ In Foundry VTT:
 ## 📋 Branch Strategy
 
 ```
-staging (beta releases)
-   ↓
-   ↓ (merge when ready)
-   ↓
-main (production releases)
+                     staging (v14 beta releases)
+                        ↓
+                        ↓ (merge tested work when ready)
+                        ↓
+                     release/v14 (v14 production releases) ──┐
+                                                              ├─→ same Foundry listing,
+                     main (v13 production releases) ─────────┘   different version entries
 ```
 
+`main` and `staging`/`release/v14` are independent lines — `main` no longer
+receives the v14 rewrite. Fixes that apply to both must be ported by hand
+(cherry-pick or reimplement), not by merging the branches into each other.
+
 ### Typical workflow:
-1. **Development:** Make changes on feature branches, merge to `staging`
-2. **Beta Testing:** Push version bump to `staging` → creates beta release
-3. **Testing:** Testers install beta via manifest URL and provide feedback
-4. **Release:** When ready, merge `staging` to `main` → creates production release
+1. **v14 development:** Make changes on feature branches, merge to `staging`
+2. **v14 Beta Testing:** Push version bump to `staging` → creates beta release
+3. **v14 Release:** When ready, merge `staging` to `release/v14` → creates v14 production release
+4. **v13 maintenance:** Fixes/parity changes for the legacy line go directly to `main` → creates v13 production release
 
 ---
 
 ## 🔧 Version Numbering
 
-### Production (main):
+### Production v13 (main):
 - Tag: `v1.2.0`
 - Version in module.json: `1.2.0`
-- Manifest URL: `/releases/latest/download/module.json` (auto-updates)
+- Manifest URL: `/releases/download/v13-latest/module.json` (auto-updates)
 - Download URL: `/releases/download/v1.2.0/module.zip` (specific version)
+
+### Production v14 (release/v14):
+- Tag: `v2.1.0`
+- Version in module.json: `2.1.0`
+- Manifest URL: `/releases/download/v14-latest/module.json` (auto-updates)
+- Download URL: `/releases/download/v2.1.0/module.zip` (specific version)
 
 ### Beta (staging):
 - **Versioned tag:** `v1.2.0-beta.5` (specific beta with full changelog)

--- a/.github/RELEASE_WORKFLOW.md
+++ b/.github/RELEASE_WORKFLOW.md
@@ -7,7 +7,7 @@ package, each with its own compatibility range — the Foundry client picks
 whichever version matches the user's installed core version, so no separate
 listing/package id is needed.
 
-There are four GitHub Actions workflows involved:
+There are three GitHub Actions workflows involved:
 
 | Branch | Workflow | Publishes to Foundry? | Version family |
 |---|---|---|---|
@@ -62,6 +62,12 @@ Same steps as the v13 workflow above, but requires `module.json` version to be
 `v14-latest` tag/release instead of `v13-latest`. Publishes to the **same**
 Foundry package listing as `main` (same `FOUNDRY_ADMIN_MODULE_ID`), as a
 separate version entry with its own compatibility range.
+
+Its GitHub releases are created with `make_latest: false`, so the repo-wide
+`/releases/latest` URL always stays on the v13 track. This protects v13 users
+who installed before `v13-latest` existed and still have
+`/releases/latest/download/module.json` stored as their manifest URL — without
+it, each v14 publish would silently repoint those installs at v14.
 
 ### How to create a v14 production release:
 1. Merge tested `staging` work into `release/v14` (create the branch from
@@ -147,13 +153,13 @@ receives the v14 rewrite. Fixes that apply to both must be ported by hand
 - Tag: `v1.2.0`
 - Version in module.json: `1.2.0`
 - Manifest URL: `/releases/download/v13-latest/module.json` (auto-updates)
-- Download URL: `/releases/download/v1.2.0/module.zip` (specific version)
+- Download URL in the published manifest: `/releases/download/v13-latest/module.zip` (auto-updates; each versioned release also keeps its own zip at `/releases/download/v1.2.0/module.zip`)
 
 ### Production v14 (release/v14):
 - Tag: `v2.1.0`
 - Version in module.json: `2.1.0`
 - Manifest URL: `/releases/download/v14-latest/module.json` (auto-updates)
-- Download URL: `/releases/download/v2.1.0/module.zip` (specific version)
+- Download URL in the published manifest: `/releases/download/v14-latest/module.zip` (auto-updates; each versioned release also keeps its own zip at `/releases/download/v2.1.0/module.zip`)
 
 ### Beta (staging):
 - **Versioned tag:** `v1.2.0-beta.5` (specific beta with full changelog)
@@ -187,28 +193,26 @@ receives the v14 rewrite. Fixes that apply to both must be ported by hand
 - Make changes but don't update the version numbers
 - Or use `[skip ci]` in your commit message
 
-### Merging staging to main
+### Promoting staging to release/v14
 - The `staging` branch's `module.json` will have beta URLs:
   ```json
   "manifest": "https://github.com/camrun91/archivist-sync/releases/download/beta-latest/module.json",
   "download": "https://github.com/camrun91/archivist-sync/releases/download/beta-latest/module.zip"
   ```
-- Before merging to main, update these to production URLs:
-  ```json
-  "manifest": "https://github.com/camrun91/archivist-sync/releases/latest/download/module.json",
-  "download": "https://github.com/camrun91/archivist-sync/releases/download/v1.2.0/module.zip"
-  ```
-- The main branch should use `releases/latest/download/` for manifest (auto-updates)
-- Update the download URL to match the version you're releasing
+- You do **not** need to fix these by hand: both stable workflows rewrite the
+  `manifest`/`download` fields to their own track's moving tag (`v13-latest` or
+  `v14-latest`) before packaging, precisely so leaked beta URLs can't ship.
+- Do **not** point any manifest at `releases/latest/download/` — that URL is
+  repo-wide and no longer belongs to either track.
 
 ---
 
 ## 🎯 Best Practices
 
 1. **Always update CHANGELOG.md** before releasing (production)
-2. **Test on staging** before merging to main
+2. **Test on staging** before promoting to `release/v14`
 3. **Keep versions in sync** between `module.json` and `package.json`
 4. **Use semantic versioning**: `MAJOR.MINOR.PATCH`
 5. **Beta testing**: Share the beta manifest URL with trusted testers
-6. **Production release**: Only merge to main when ready for public release
+6. **Production release**: Only push to `main` (v13) or `release/v14` (v14) when ready for public release
 

--- a/.github/RELEASE_WORKFLOW.md
+++ b/.github/RELEASE_WORKFLOW.md
@@ -70,11 +70,23 @@ who installed before `v13-latest` existed and still have
 it, each v14 publish would silently repoint those installs at v14.
 
 ### How to create a v14 production release:
-1. Merge tested `staging` work into `release/v14` (create the branch from
-   `staging` if it doesn't exist yet)
-2. Update version in both `module.json` and `package.json` (keep it in the `2.x` family, compat `14.x`)
-3. Add a section for the new version in `CHANGELOG.md`
-4. Push to `release/v14` — the workflow creates the release and publishes to Foundry
+1. If `release/v14` doesn't exist yet, create it from a commit that already
+   contains `.github/workflows/auto-release-v14.yml` — i.e. from `main` after
+   the dual-publish CI merged, or cherry-pick that workflow file onto the new
+   branch.
+   > ⚠️ Do **not** branch `release/v14` off `staging` alone. GitHub evaluates
+   > workflows from the ref being pushed, so a `release/v14` without
+   > `auto-release-v14.yml` accepts version bumps and silently publishes
+   > nothing.
+2. Merge/promote tested `staging` work into `release/v14`
+3. Resolve the version in both `module.json` and `package.json` (keep it in the
+   `2.x` family, compat `14.x`) — `staging` merges often carry beta or `1.x`
+   values that the workflow will reject
+4. Add a section for the new version in `CHANGELOG.md`
+5. Push to `release/v14` — the workflow creates the release and publishes to Foundry
+
+Before the *first* v14 stable release, complete the one-time
+[Pre-v14 cutover](#-pre-v14-cutover-required-once) checklist.
 
 ---
 
@@ -147,19 +159,49 @@ receives the v14 rewrite. Fixes that apply to both must be ported by hand
 
 ---
 
+## 🔀 Pre-v14 cutover (required once)
+
+Installs made before `v13-latest` existed still store
+`/releases/latest/download/module.json` as their manifest URL. That URL is
+repo-wide, so whichever release GitHub last marked "latest" owns those users.
+Run this checklist **once, before the first `release/v14` publish**:
+
+1. **Reclaim `/releases/latest` for v13.** Push a normal v13 production release
+   on `main`. Its release is created with `make_latest: true`, which moves the
+   repo-wide latest pointer back onto the v13 track.
+2. **Confirm it took.** Open the repo's Releases page (or
+   `/releases/latest`) and verify the release badged "Latest" is a `v1.x`
+   release.
+3. **Only then publish v14.** Create/push the first `release/v14` stable
+   release. Its workflow uses `make_latest: false`, so it never touches the
+   repo-wide latest pointer.
+4. **Optional user migration.** Legacy installs stay safe as long as `main`
+   keeps reclaiming latest and `release/v14` never sets `make_latest`. Users
+   who *want* the moving v13 track explicitly can reinstall with
+   `https://github.com/camrun91/archivist-sync/releases/download/v13-latest/module.json`.
+
+---
+
 ## 🔧 Version Numbering
 
 ### Production v13 (main):
 - Tag: `v1.2.0`
 - Version in module.json: `1.2.0`
 - Manifest URL: `/releases/download/v13-latest/module.json` (auto-updates)
-- Download URL in the published manifest: `/releases/download/v13-latest/module.zip` (auto-updates; each versioned release also keeps its own zip at `/releases/download/v1.2.0/module.zip`)
+- Download URL in the published manifest: `/releases/download/v1.2.0/module.zip` (immutable for that release)
 
 ### Production v14 (release/v14):
 - Tag: `v2.1.0`
 - Version in module.json: `2.1.0`
 - Manifest URL: `/releases/download/v14-latest/module.json` (auto-updates)
-- Download URL in the published manifest: `/releases/download/v14-latest/module.zip` (auto-updates; each versioned release also keeps its own zip at `/releases/download/v2.1.0/module.zip`)
+- Download URL in the published manifest: `/releases/download/v2.1.0/module.zip` (immutable for that release)
+
+**Manifest vs. download:** only the *manifest* URL moves. Each track's
+`*-latest` release also hosts copies of `module.json` and `module.zip` so
+Foundry's update check always reads the newest version for that track — but the
+`download` field inside every published `module.json` points at that release's
+own versioned zip. A given version therefore always installs the exact bits it
+was built from, even after a newer release moves the `*-latest` tag.
 
 ### Beta (staging):
 - **Versioned tag:** `v1.2.0-beta.5` (specific beta with full changelog)
@@ -199,11 +241,15 @@ receives the v14 rewrite. Fixes that apply to both must be ported by hand
   "manifest": "https://github.com/camrun91/archivist-sync/releases/download/beta-latest/module.json",
   "download": "https://github.com/camrun91/archivist-sync/releases/download/beta-latest/module.zip"
   ```
-- You do **not** need to fix these by hand: both stable workflows rewrite the
-  `manifest`/`download` fields to their own track's moving tag (`v13-latest` or
-  `v14-latest`) before packaging, precisely so leaked beta URLs can't ship.
-- Do **not** point any manifest at `releases/latest/download/` — that URL is
-  repo-wide and no longer belongs to either track.
+- You do **not** need to fix these by hand: both stable workflows rewrite these
+  fields before packaging, precisely so leaked beta URLs can't ship — `manifest`
+  becomes their own track's moving tag (`v13-latest` or `v14-latest`), and
+  `download` becomes that release's versioned zip (`/releases/download/v2.1.0/module.zip`).
+- Do **not** point any manifest at `releases/latest/download/`, and do **not**
+  hand-edit which release GitHub marks "latest". That pointer is repo-wide and is
+  managed by the workflows: `main` claims it (`make_latest: true`), `release/v14`
+  leaves it alone (`make_latest: false`). See
+  [Pre-v14 cutover](#-pre-v14-cutover-required-once).
 
 ---
 

--- a/.github/workflows/auto-release-v14.yml
+++ b/.github/workflows/auto-release-v14.yml
@@ -53,6 +53,23 @@ jobs:
         run: |
           COMPAT_MIN=$(jq -r '.compatibility.minimum' module.json)
 
+          # Reject empty, prerelease, or non-semver stable versions before
+          # the track-family check. Bash glob `1.*`/`2.*` would otherwise
+          # accept strings like `2.0.0-beta.28` as valid for a stable publish.
+          if [[ -z "$VERSION" ]]; then
+            echo "❌ Refusing to publish: module.json version is empty."
+            exit 1
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            echo "❌ Refusing to publish: prerelease version '$VERSION' cannot be published as stable."
+            echo "   Strip any -beta/-rc/-alpha suffix from module.json before releasing."
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[12]\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Refusing to publish: version '$VERSION' is not a stable X.Y.Z semver."
+            exit 1
+          fi
+
           # release/v14 publishes the v14 track (2.x / compat 14.x). Refuse to
           # publish a v13-shaped build here — same mistake as main, mirrored.
           if [[ "$VERSION" != 2.* ]]; then

--- a/.github/workflows/auto-release-v14.yml
+++ b/.github/workflows/auto-release-v14.yml
@@ -121,17 +121,19 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         env:
           REPO: ${{ github.repository }}
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          # Point at the moving "v14-latest" tag, not GitHub's built-in
+          # Point manifest at the moving "v14-latest" tag, not GitHub's built-in
           # "releases/latest" — main's auto-release.yml also publishes
           # non-prerelease GitHub releases to this same repo, so
           # "releases/latest" would flip between the v13 and v14 tracks.
           # "v14-latest" is a tag this workflow owns and moves itself
           # (mirroring beta-release.yml's beta-latest and auto-release.yml's
-          # new v13-latest).
-          jq --arg repo "$REPO" \
+          # new v13-latest). Download stays on the immutable version tag so
+          # each release's zip URL never changes when v14-latest moves.
+          jq --arg repo "$REPO" --arg tag "$TAG" \
             '.manifest = "https://github.com/\($repo)/releases/download/v14-latest/module.json" |
-             .download = "https://github.com/\($repo)/releases/download/v14-latest/module.zip"' \
+             .download = "https://github.com/\($repo)/releases/download/\($tag)/module.zip"' \
             module.json > module.json.tmp && mv module.json.tmp module.json
 
           echo "✅ Ensured production URLs in module.json"
@@ -184,6 +186,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.TAG }}
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.get_version.outputs.VERSION }} (v14)
           body_path: release_notes.md
           draft: false
@@ -230,6 +233,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v14-latest
+          target_commitish: ${{ github.sha }}
           name: Latest v14 Stable Release
           body: |
             This is an automatically updated release that always points to the

--- a/.github/workflows/auto-release-v14.yml
+++ b/.github/workflows/auto-release-v14.yml
@@ -1,9 +1,17 @@
-name: Auto Release on Version Bump
+name: Auto Release v14 on Version Bump
+
+# Stable release channel for the Foundry v14 line, parallel to auto-release.yml
+# (which handles the legacy v13 line on `main`). Both publish to the SAME
+# Foundry package listing (same FOUNDRY_ADMIN_MODULE_ID) as separate versions
+# with independent compatibility ranges — Foundry's client picks whichever
+# version matches the user's installed core version. `staging` remains the
+# beta/dev channel and does not publish to Foundry; this workflow is what
+# actually ships a tested v14 build to the live registry.
 
 on:
   push:
     branches:
-      - main
+      - release/v14
     paths:
       - "module.json"
       - "package.json"
@@ -34,20 +42,18 @@ jobs:
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           COMPAT_MIN=$(jq -r '.compatibility.minimum' module.json)
 
-          # main publishes the legacy Foundry v13 track (1.x / compat 13.x).
-          # A v14-shaped commit landing here and auto-publishing under a v13
-          # version string is exactly the incident that broke v13 users
-          # previously — refuse instead of repeating it.
-          if [[ "$VERSION" != 1.* ]]; then
-            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 1.x (v13) family expected on main."
-            echo "   If this is intentionally a v14 release, it belongs on the release/v14 branch, not main."
+          # release/v14 publishes the v14 track (2.x / compat 14.x). Refuse to
+          # publish a v13-shaped build here — same mistake as main, mirrored.
+          if [[ "$VERSION" != 2.* ]]; then
+            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 2.x (v14) family expected on release/v14."
+            echo "   If this is intentionally a v13 release, it belongs on main, not release/v14."
             exit 1
           fi
-          if [[ "$COMPAT_MIN" != 13.* ]]; then
-            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 13.x range expected on main."
+          if [[ "$COMPAT_MIN" != 14.* ]]; then
+            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 14.x range expected on release/v14."
             exit 1
           fi
-          echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v13 track."
+          echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v14 track."
 
       - name: Check if package.json version matches
         run: |
@@ -99,26 +105,21 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: npm ci
 
-      # - name: Run linter
-      #   if: steps.check_release.outputs.exists == 'false'
-      #   run: npm run lint
-
       - name: Ensure production URLs in module.json
         if: steps.check_release.outputs.exists == 'false'
         run: |
           REPO="${{ github.repository }}"
 
-          # Point at the moving "v13-latest" tag, not GitHub's built-in
-          # "releases/latest" — now that a second stable track (release/v14)
-          # also publishes non-prerelease GitHub releases to this same repo,
-          # "releases/latest" would flip between the v13 and v14 tracks
-          # depending on which published most recently, silently pointing a
-          # v13 user's stored manifest URL at v14's module.json (or vice
-          # versa). "v13-latest" is a tag this workflow owns and moves itself
-          # (mirroring how beta-release.yml already does this for beta-latest).
+          # Point at the moving "v14-latest" tag, not GitHub's built-in
+          # "releases/latest" — main's auto-release.yml also publishes
+          # non-prerelease GitHub releases to this same repo, so
+          # "releases/latest" would flip between the v13 and v14 tracks.
+          # "v14-latest" is a tag this workflow owns and moves itself
+          # (mirroring beta-release.yml's beta-latest and auto-release.yml's
+          # new v13-latest).
           jq --arg repo "$REPO" \
-            '.manifest = "https://github.com/\($repo)/releases/download/v13-latest/module.json" |
-             .download = "https://github.com/\($repo)/releases/download/v13-latest/module.zip"' \
+            '.manifest = "https://github.com/\($repo)/releases/download/v14-latest/module.json" |
+             .download = "https://github.com/\($repo)/releases/download/v14-latest/module.zip"' \
             module.json > module.json.tmp && mv module.json.tmp module.json
 
           echo "✅ Ensured production URLs in module.json"
@@ -171,7 +172,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_version.outputs.TAG }}
-          name: Release ${{ steps.get_version.outputs.VERSION }}
+          name: Release ${{ steps.get_version.outputs.VERSION }} (v14)
           body_path: release_notes.md
           draft: false
           prerelease: false
@@ -193,29 +194,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update v13-latest tag
+      - name: Update v14-latest tag
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          git tag -d v13-latest 2>/dev/null || true
-          git push origin :refs/tags/v13-latest 2>/dev/null || true
-          git tag -a v13-latest -m "Latest v13 stable release: ${{ steps.get_version.outputs.VERSION }}"
-          git push origin v13-latest
+          git tag -d v14-latest 2>/dev/null || true
+          git push origin :refs/tags/v14-latest 2>/dev/null || true
+          git tag -a v14-latest -m "Latest v14 stable release: ${{ steps.get_version.outputs.VERSION }}"
+          git push origin v14-latest
 
-      - name: Create/Update v13-latest Release
+      - name: Create/Update v14-latest Release
         if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v13-latest
-          name: Latest v13 Stable Release
+          tag_name: v14-latest
+          name: Latest v14 Stable Release
           body: |
             This is an automatically updated release that always points to the
-            most recent v13 (legacy) stable version.
+            most recent v14 stable version.
 
             **Current Version:** ${{ steps.get_version.outputs.VERSION }}
 
             Manifest URL for direct install:
             ```
-            https://github.com/${{ github.repository }}/releases/download/v13-latest/module.json
+            https://github.com/${{ github.repository }}/releases/download/v14-latest/module.json
             ```
 
             For the full release notes, see [${{ steps.get_version.outputs.TAG }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.TAG }}).
@@ -240,7 +241,7 @@ jobs:
       - name: Notify on Success
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          echo "✅ Release ${{ steps.get_version.outputs.VERSION }} published successfully!"
+          echo "✅ Release ${{ steps.get_version.outputs.VERSION }} (v14) published successfully!"
           echo "📦 Module archive: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.zip"
           echo "📄 Manifest: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.json"
-          echo "🌐 Published to Foundry VTT package repository"
+          echo "🌐 Published to Foundry VTT package repository (v14 track)"

--- a/.github/workflows/auto-release-v14.yml
+++ b/.github/workflows/auto-release-v14.yml
@@ -16,6 +16,16 @@ on:
       - "module.json"
       - "package.json"
 
+# Serialize v14 stable releases. This job force-moves the shared `v14-latest`
+# tag; two overlapping runs would race on delete/recreate and could leave the
+# tag pointing at the older release. Queue instead of cancelling — cancelling
+# mid-publish could leave a GitHub release without its Foundry registry entry.
+# Separate group from the v13 track: the two never touch the same tags, so
+# they are free to publish concurrently.
+concurrency:
+  group: stable-release-v14
+  cancel-in-progress: false
+
 jobs:
   check-and-release:
     name: Check Version and Release
@@ -38,8 +48,9 @@ jobs:
           echo "📦 Current version in module.json: $VERSION"
 
       - name: Guard against publishing the wrong version line
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
           COMPAT_MIN=$(jq -r '.compatibility.minimum' module.json)
 
           # release/v14 publishes the v14 track (2.x / compat 14.x). Refuse to
@@ -56,9 +67,10 @@ jobs:
           echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v14 track."
 
       - name: Check if package.json version matches
+        env:
+          MODULE_VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           PACKAGE_VERSION=$(jq -r '.version' package.json)
-          MODULE_VERSION="${{ steps.get_version.outputs.VERSION }}"
 
           if [ "$PACKAGE_VERSION" != "$MODULE_VERSION" ]; then
             echo "❌ Version mismatch!"
@@ -70,9 +82,9 @@ jobs:
           echo "✅ Versions match: $MODULE_VERSION"
 
       - name: Check if CHANGELOG has been updated
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-
           if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
             echo "❌ CHANGELOG.md has not been updated for version $VERSION"
             echo "   Please add a section for version $VERSION in CHANGELOG.md"
@@ -83,9 +95,9 @@ jobs:
 
       - name: Check if release already exists
         id: check_release
+        env:
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          TAG="${{ steps.get_version.outputs.TAG }}"
-
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "ℹ️  Tag $TAG already exists, skipping release"
@@ -107,9 +119,9 @@ jobs:
 
       - name: Ensure production URLs in module.json
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          REPO="${{ github.repository }}"
-
           # Point at the moving "v14-latest" tag, not GitHub's built-in
           # "releases/latest" — main's auto-release.yml also publishes
           # non-prerelease GitHub releases to this same repo, so
@@ -148,9 +160,9 @@ jobs:
       - name: Extract changelog for this version
         if: steps.check_release.outputs.exists == 'false'
         id: changelog
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-
           # Extract changelog section for this version
           if [ -f CHANGELOG.md ]; then
             awk "/## \[$VERSION\]/,/## \[/" CHANGELOG.md | sed '$d' > release_notes.md
@@ -169,13 +181,20 @@ jobs:
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.TAG }}
           name: Release ${{ steps.get_version.outputs.VERSION }} (v14)
           body_path: release_notes.md
           draft: false
           prerelease: false
+          # Keep GitHub's repo-wide /releases/latest pinned to the v13 track.
+          # v13 users who installed before v13-latest existed still have
+          # /releases/latest/download/module.json stored as their manifest URL;
+          # if a v14 release ever became the repo's "latest", Foundry would
+          # auto-update those users onto v14 — the exact incident the version
+          # guards exist to prevent.
+          make_latest: false
           files: |
             module.zip
             module.json
@@ -184,8 +203,10 @@ jobs:
 
       - name: Set release environment variables
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          echo "RELEASE_NAME=${{ steps.get_version.outputs.TAG }}" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$TAG" >> $GITHUB_ENV
           echo "MANIFEST_FILE_PATH=module.json" >> $GITHUB_ENV
 
       - name: Configure Git
@@ -196,15 +217,17 @@ jobs:
 
       - name: Update v14-latest tag
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           git tag -d v14-latest 2>/dev/null || true
           git push origin :refs/tags/v14-latest 2>/dev/null || true
-          git tag -a v14-latest -m "Latest v14 stable release: ${{ steps.get_version.outputs.VERSION }}"
+          git tag -a v14-latest -m "Latest v14 stable release: $VERSION"
           git push origin v14-latest
 
       - name: Create/Update v14-latest Release
         if: steps.check_release.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v14-latest
           name: Latest v14 Stable Release
@@ -222,6 +245,9 @@ jobs:
             For the full release notes, see [${{ steps.get_version.outputs.TAG }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.TAG }}).
           draft: false
           prerelease: false
+          # Same reason as the versioned release above: repo-wide
+          # /releases/latest must stay on the v13 track for legacy installs.
+          make_latest: false
           files: |
             module.zip
             module.json
@@ -240,8 +266,12 @@ jobs:
 
       - name: Notify on Success
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          TAG: ${{ steps.get_version.outputs.TAG }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "✅ Release ${{ steps.get_version.outputs.VERSION }} (v14) published successfully!"
-          echo "📦 Module archive: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.zip"
-          echo "📄 Manifest: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.json"
+          echo "✅ Release $VERSION (v14) published successfully!"
+          echo "📦 Module archive: https://github.com/$REPO/releases/download/$TAG/module.zip"
+          echo "📄 Manifest: https://github.com/$REPO/releases/download/$TAG/module.json"
           echo "🌐 Published to Foundry VTT package repository (v14 track)"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -117,8 +117,9 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         env:
           REPO: ${{ github.repository }}
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          # Point at the moving "v13-latest" tag, not GitHub's built-in
+          # Point manifest at the moving "v13-latest" tag, not GitHub's built-in
           # "releases/latest" — now that a second stable track (release/v14)
           # also publishes non-prerelease GitHub releases to this same repo,
           # "releases/latest" would flip between the v13 and v14 tracks
@@ -126,9 +127,11 @@ jobs:
           # v13 user's stored manifest URL at v14's module.json (or vice
           # versa). "v13-latest" is a tag this workflow owns and moves itself
           # (mirroring how beta-release.yml already does this for beta-latest).
-          jq --arg repo "$REPO" \
+          # Download stays on the immutable version tag so each release's zip URL
+          # never changes when v13-latest moves.
+          jq --arg repo "$REPO" --arg tag "$TAG" \
             '.manifest = "https://github.com/\($repo)/releases/download/v13-latest/module.json" |
-             .download = "https://github.com/\($repo)/releases/download/v13-latest/module.zip"' \
+             .download = "https://github.com/\($repo)/releases/download/\($tag)/module.zip"' \
             module.json > module.json.tmp && mv module.json.tmp module.json
 
           echo "✅ Ensured production URLs in module.json"
@@ -181,6 +184,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.TAG }}
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.get_version.outputs.VERSION }}
           body_path: release_notes.md
           draft: false
@@ -224,6 +228,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v13-latest
+          target_commitish: ${{ github.sha }}
           name: Latest v13 Stable Release
           body: |
             This is an automatically updated release that always points to the

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,6 +8,14 @@ on:
       - "module.json"
       - "package.json"
 
+# Serialize v13 stable releases. This job force-moves the shared `v13-latest`
+# tag; two overlapping runs would race on delete/recreate and could leave the
+# tag pointing at the older release. Queue instead of cancelling — cancelling
+# mid-publish could leave a GitHub release without its Foundry registry entry.
+concurrency:
+  group: stable-release-v13
+  cancel-in-progress: false
+
 jobs:
   check-and-release:
     name: Check Version and Release
@@ -30,8 +38,9 @@ jobs:
           echo "📦 Current version in module.json: $VERSION"
 
       - name: Guard against publishing the wrong version line
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
           COMPAT_MIN=$(jq -r '.compatibility.minimum' module.json)
 
           # main publishes the legacy Foundry v13 track (1.x / compat 13.x).
@@ -50,9 +59,10 @@ jobs:
           echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v13 track."
 
       - name: Check if package.json version matches
+        env:
+          MODULE_VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           PACKAGE_VERSION=$(jq -r '.version' package.json)
-          MODULE_VERSION="${{ steps.get_version.outputs.VERSION }}"
 
           if [ "$PACKAGE_VERSION" != "$MODULE_VERSION" ]; then
             echo "❌ Version mismatch!"
@@ -64,9 +74,9 @@ jobs:
           echo "✅ Versions match: $MODULE_VERSION"
 
       - name: Check if CHANGELOG has been updated
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-
           if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
             echo "❌ CHANGELOG.md has not been updated for version $VERSION"
             echo "   Please add a section for version $VERSION in CHANGELOG.md"
@@ -77,9 +87,9 @@ jobs:
 
       - name: Check if release already exists
         id: check_release
+        env:
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          TAG="${{ steps.get_version.outputs.TAG }}"
-
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "ℹ️  Tag $TAG already exists, skipping release"
@@ -105,9 +115,9 @@ jobs:
 
       - name: Ensure production URLs in module.json
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          REPO="${{ github.repository }}"
-
           # Point at the moving "v13-latest" tag, not GitHub's built-in
           # "releases/latest" — now that a second stable track (release/v14)
           # also publishes non-prerelease GitHub releases to this same repo,
@@ -147,9 +157,9 @@ jobs:
       - name: Extract changelog for this version
         if: steps.check_release.outputs.exists == 'false'
         id: changelog
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-
           # Extract changelog section for this version
           if [ -f CHANGELOG.md ]; then
             awk "/## \[$VERSION\]/,/## \[/" CHANGELOG.md | sed '$d' > release_notes.md
@@ -168,13 +178,17 @@ jobs:
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.TAG }}
           name: Release ${{ steps.get_version.outputs.VERSION }}
           body_path: release_notes.md
           draft: false
           prerelease: false
+          # Reclaim repo-wide /releases/latest for the v13 track. Legacy installs
+          # still use /releases/latest/download/module.json; v14 releases set
+          # make_latest: false, but each v13 publish must actively pin latest here.
+          make_latest: true
           files: |
             module.zip
             module.json
@@ -183,8 +197,10 @@ jobs:
 
       - name: Set release environment variables
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
-          echo "RELEASE_NAME=${{ steps.get_version.outputs.TAG }}" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$TAG" >> $GITHUB_ENV
           echo "MANIFEST_FILE_PATH=module.json" >> $GITHUB_ENV
 
       - name: Configure Git
@@ -195,15 +211,17 @@ jobs:
 
       - name: Update v13-latest tag
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           git tag -d v13-latest 2>/dev/null || true
           git push origin :refs/tags/v13-latest 2>/dev/null || true
-          git tag -a v13-latest -m "Latest v13 stable release: ${{ steps.get_version.outputs.VERSION }}"
+          git tag -a v13-latest -m "Latest v13 stable release: $VERSION"
           git push origin v13-latest
 
       - name: Create/Update v13-latest Release
         if: steps.check_release.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v13-latest
           name: Latest v13 Stable Release
@@ -221,6 +239,8 @@ jobs:
             For the full release notes, see [${{ steps.get_version.outputs.TAG }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.TAG }}).
           draft: false
           prerelease: false
+          # Same reason as the versioned release above: keep /releases/latest on v13.
+          make_latest: true
           files: |
             module.zip
             module.json
@@ -239,8 +259,12 @@ jobs:
 
       - name: Notify on Success
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          TAG: ${{ steps.get_version.outputs.TAG }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "✅ Release ${{ steps.get_version.outputs.VERSION }} published successfully!"
-          echo "📦 Module archive: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.zip"
-          echo "📄 Manifest: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.TAG }}/module.json"
+          echo "✅ Release $VERSION published successfully!"
+          echo "📦 Module archive: https://github.com/$REPO/releases/download/$TAG/module.zip"
+          echo "📄 Manifest: https://github.com/$REPO/releases/download/$TAG/module.json"
           echo "🌐 Published to Foundry VTT package repository"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,6 +43,23 @@ jobs:
         run: |
           COMPAT_MIN=$(jq -r '.compatibility.minimum' module.json)
 
+          # Reject empty, prerelease, or non-semver stable versions before
+          # the track-family check. Bash glob `1.*`/`2.*` would otherwise
+          # accept strings like `2.0.0-beta.28` as valid for a stable publish.
+          if [[ -z "$VERSION" ]]; then
+            echo "❌ Refusing to publish: module.json version is empty."
+            exit 1
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            echo "❌ Refusing to publish: prerelease version '$VERSION' cannot be published as stable."
+            echo "   Strip any -beta/-rc/-alpha suffix from module.json before releasing."
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[12]\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Refusing to publish: version '$VERSION' is not a stable X.Y.Z semver."
+            exit 1
+          fi
+
           # main publishes the legacy Foundry v13 track (1.x / compat 13.x).
           # A v14-shaped commit landing here and auto-publishing under a v13
           # version string is exactly the incident that broke v13 users
@@ -244,8 +261,9 @@ jobs:
             For the full release notes, see [${{ steps.get_version.outputs.TAG }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.TAG }}).
           draft: false
           prerelease: false
-          # Same reason as the versioned release above: keep /releases/latest on v13.
-          make_latest: true
+          # The versioned release above already claimed /releases/latest; this
+          # moving-tag release is an alias only — do not steal the Latest badge.
+          make_latest: false
           files: |
             module.zip
             module.json


### PR DESCRIPTION
## Context

We want two live version lines on the same Foundry package listing: legacy v13 (\`main\`, 1.x) and v14 (2.x). Foundry's package page already supports one listing with multiple versions, each with its own compatibility range — confirmed by checking the actual live listing (foundryvtt.com/packages/archivist-sync), so this needs no registry restructuring, just a second stable-publish path feeding the same module id.

This also closes a real gap found while tracing the mechanics of the v14-breaks-v13 incident this project is recovering from: \`v1.3.13\` and \`v2.0.0-beta.28\` were tagged on the identical commit in this repo's history, and \`auto-release.yml\` fires a real Foundry publish on **any** push to \`main\` that bumps \`module.json\` — no check that the version being published is actually in the right family. That's precisely the shape of mistake that would let a v14-configured commit publish under a v13-looking tag (or vice versa).

## What's here

- **New `auto-release-v14.yml`**: mirrors `auto-release.yml` but triggers on push to a new `release/v14` branch (doesn't exist yet — this workflow is inert until it's created), publishes to the same `FOUNDRY_ADMIN_MODULE_ID` as a separate version entry, requires `module.json` version `2.x` / `compatibility.minimum` `14.x`.
- **Version-family guards on both workflows**: `auto-release.yml` now refuses to run unless version is `1.x` and `compatibility.minimum` is `13.x`; the new v14 workflow mirrors that for `2.x`/`14.x`. Either one fails loudly and exits before touching the release/publish steps if the version doesn't match its branch's expected family.
- **Fixed a related latent bug**: both workflows' own `module.json` `manifest`/`download` fields used to point at GitHub's built-in `releases/latest`, which is repo-wide — once a second stable track also publishes non-prerelease releases to this repo, whichever published most recently would silently take over the other track's "latest" URL, pointing a v13 user's stored manifest at v14's `module.json` or vice versa. Each track now owns its own moving tag (\`v13-latest\` / \`v14-latest\`), mirroring how \`beta-release.yml\` already does this for \`beta-latest\`.
- Updated \`.github/RELEASE_WORKFLOW.md\` for the new dual-track model.

## What this does NOT do

Doesn't create \`release/v14\` or push anything that would actually fire a publish — that's a deliberate next step once #47/#48 are reviewed and merged, not part of this PR. Nothing here changes current `main` publish behavior beyond the added guard (which only blocks a publish that was already wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR establishes a dual stable-publish track by adding `auto-release-v14.yml` (triggering on `release/v14`) alongside the updated `auto-release.yml` (on `main`), both publishing to the same Foundry package listing under separate compatibility ranges. It also closes a real latent bug: both workflows now rewrite the `module.json` manifest to their own moving tag (`v13-latest` / `v14-latest`) instead of the repo-wide `releases/latest` URL, preventing one track's publish from silently hijacking the other track's update pointer.

- **New `auto-release-v14.yml`**: mirrors the v13 workflow with correct concurrency serialization, pre-release version guard (rejects `*-*` strings), `make_latest: false` on all releases to preserve the v13 Latest badge, and a `v14-latest` moving tag.
- **`auto-release.yml` updates**: adds a symmetric version-family guard (rejects non-`1.x` versions and non-`13.x` compat), upgrades to `softprops/action-gh-release@v2`, introduces a `v13-latest` moving tag, and moves inline `${{ }}` expressions into `env:` blocks.
- **Documentation**: `RELEASE_WORKFLOW.md` is updated with a dual-track branch diagram, a one-time pre-v14 cutover checklist, and updated `manifest`/`download` URL examples.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new workflow is inert until `release/v14` is created, and the only behavioral change to the currently-active `main` path is the added version guard and the `v13-latest` moving tag, both of which fail loudly rather than silently.

The core risk this PR guards against (wrong-track publish) is addressed with explicit, noisy early exits. The new `auto-release-v14.yml` cannot fire until a `release/v14` branch is pushed. The moving-tag pattern mirrors the already-proven `beta-latest` approach. The only findings are edge-case false-positive guards on bare-integer Foundry compat values, which produce loud CI failures rather than silent bad publishes.

**Files Needing Attention:** No files require special attention — the two suggestions on the COMPAT_MIN glob are low-priority and both workflows are otherwise structurally sound.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-release-v14.yml | New v14 stable publish workflow — correctly mirrors auto-release.yml with the right concurrency group, pre-release guard, `make_latest: false`, and `v14-latest` moving tag; minor: COMPAT_MIN glob rejects valid bare-integer Foundry compat values. |
| .github/workflows/auto-release.yml | Added version-family guard, pre-release check, `v13-latest` moving-tag logic, and concurrency group; upgraded action to `@v2`; `make_latest` set correctly on both releases; COMPAT_MIN glob has the same bare-integer edge case as the v14 workflow. |
| .github/RELEASE_WORKFLOW.md | Documentation updated to reflect dual-track model with accurate branch strategy, `v13-latest`/`v14-latest` moving-tag explanation, pre-v14 cutover checklist, and warnings about `release/v14` bootstrap ordering. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: harden stable release guards and La..."](https://github.com/camrun91/archivist-sync/commit/1ccf05087466ae08b306059d696601ed9088a1bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49082722)</sub>

<!-- /greptile_comment -->