### PR TITLE
Invert dual-track (2/3): swap stable release triggers

### DIFF
--- a/.github/workflows/auto-release-v13.yml
+++ b/.github/workflows/auto-release-v13.yml
@@ -1,9 +1,9 @@
-name: Auto Release on Version Bump
+name: Auto Release v13 on Version Bump
 
 on:
   push:
     branches:
-      - main
+      - release/v13
     paths:
       - "module.json"
       - "package.json"
@@ -60,17 +60,17 @@ jobs:
             exit 1
           fi
 
-          # main publishes the legacy Foundry v13 track (1.x / compat 13.x).
+          # release/v13 publishes the legacy Foundry v13 track (1.x / compat 13.x).
           # A v14-shaped commit landing here and auto-publishing under a v13
           # version string is exactly the incident that broke v13 users
           # previously — refuse instead of repeating it.
           if [[ "$VERSION" != 1.* ]]; then
-            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 1.x (v13) family expected on main."
-            echo "   If this is intentionally a v14 release, it belongs on the release/v14 branch, not main."
+            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 1.x (v13) family expected on release/v13."
+            echo "   If this is intentionally a v14 release, it belongs on main, not release/v13."
             exit 1
           fi
           if [[ "$COMPAT_MIN" != 13.* ]]; then
-            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 13.x range expected on main."
+            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 13.x range expected on release/v13."
             exit 1
           fi
           echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v13 track."
@@ -137,7 +137,7 @@ jobs:
           TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
           # Point manifest at the moving "v13-latest" tag, not GitHub's built-in
-          # "releases/latest" — now that a second stable track (release/v14)
+          # "releases/latest" — now that a second stable track (main, v14)
           # also publishes non-prerelease GitHub releases to this same repo,
           # "releases/latest" would flip between the v13 and v14 tracks
           # depending on which published most recently, silently pointing a

--- a/.github/workflows/auto-release-v14.yml
+++ b/.github/workflows/auto-release-v14.yml
@@ -1,7 +1,7 @@
 name: Auto Release v14 on Version Bump
 
 # Stable release channel for the Foundry v14 line, parallel to auto-release.yml
-# (which handles the legacy v13 line on `main`). Both publish to the SAME
+# (which handles the legacy v13 line on `release/v13`). Both publish to the SAME
 # Foundry package listing (same FOUNDRY_ADMIN_MODULE_ID) as separate versions
 # with independent compatibility ranges — Foundry's client picks whichever
 # version matches the user's installed core version. `staging` remains the
@@ -11,7 +11,7 @@ name: Auto Release v14 on Version Bump
 on:
   push:
     branches:
-      - release/v14
+      - main
     paths:
       - "module.json"
       - "package.json"
@@ -70,15 +70,15 @@ jobs:
             exit 1
           fi
 
-          # release/v14 publishes the v14 track (2.x / compat 14.x). Refuse to
-          # publish a v13-shaped build here — same mistake as main, mirrored.
+          # main publishes the v14 track (2.x / compat 14.x). Refuse to
+          # publish a v13-shaped build here — same mistake as release/v13, mirrored.
           if [[ "$VERSION" != 2.* ]]; then
-            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 2.x (v14) family expected on release/v14."
-            echo "   If this is intentionally a v13 release, it belongs on main, not release/v14."
+            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 2.x (v14) family expected on main."
+            echo "   If this is intentionally a v13 release, it belongs on release/v13, not main."
             exit 1
           fi
           if [[ "$COMPAT_MIN" != 14.* ]]; then
-            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 14.x range expected on release/v14."
+            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 14.x range expected on main."
             exit 1
           fi
           echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v14 track."
@@ -141,7 +141,7 @@ jobs:
           TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
           # Point manifest at the moving "v14-latest" tag, not GitHub's built-in
-          # "releases/latest" — main's auto-release.yml also publishes
+          # "releases/latest" — release/v13's auto-release-v13.yml also publishes
           # non-prerelease GitHub releases to this same repo, so
           # "releases/latest" would flip between the v13 and v14 tracks.
           # "v14-latest" is a tag this workflow owns and moves itself


### PR DESCRIPTION
## What

Part **2 of 3** of the dual-track inversion. Triggers only — no guard, tag, or
`make_latest` value changes.

| File | Before | After |
|---|---|---|
| `auto-release-v14.yml` | `on.push.branches: release/v14` | `on.push.branches: main` |
| `auto-release.yml` → `auto-release-v13.yml` | `on.push.branches: main` | `on.push.branches: release/v13` |
| `beta-release.yml` | `staging` | `staging` (unchanged) |

Comment prose and guard failure messages were updated so they name the correct branch.

## Explicitly unchanged

- The `1.x`/`13.x` and `2.x`/`14.x` family guards
- `concurrency` groups `stable-release-v13` / `stable-release-v14`
- The moving `v13-latest` / `v14-latest` tags and their manifest URLs
- **`make_latest: true` on v13 and `make_latest: false` on v14.** `v13-latest` does not
  exist yet, so legacy v13 installs still resolve through the repo-wide
  `/releases/latest`. That pointer must keep landing on the v13 track. Flipping it is a
  deliberate later step, not part of this cutover.
- `paths: ["module.json", "package.json"]` on both stable workflows

## Safety

This PR changes only `.github/workflows/**`. Neither stable workflow's `paths` filter
matches, so merging it cannot start a publish.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR swaps the stable-release workflow triggers so `main` owns the v14 track and `release/v13` owns the legacy v13 track.
- Renames the legacy workflow to `auto-release-v13.yml` and targets `release/v13`.
- Retargets `auto-release-v14.yml` to `main`.
- Updates branch-specific comments and guard diagnostics without changing release guards, tags, concurrency, or latest-release behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge as the trigger changes are internally consistent and the remaining cross-branch rollout step is explicitly acknowledged by the staged cutover.

The two workflows retain their existing version-family guards, path filters, release ownership, tags, and concurrency settings while exchanging only their intended branch triggers; no unacknowledged actionable defect remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-release-v13.yml | Renames the v13 workflow, changes its trigger to `release/v13`, and updates branch-specific diagnostics and comments consistently. |
| .github/workflows/auto-release-v14.yml | Changes the v14 stable-release trigger to `main` and updates the associated branch references consistently. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: swap stable release triggers for the..."](https://github.com/camrun91/archivist-sync/commit/4ba3ad336473cae2a5f8cd371db1913cef0e2cbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50441166)</sub>

<!-- /greptile_comment -->