### PR TITLE
Invert dual-track (3/3): wire the v13 stable release workflow to release/v13

### DIFF
--- a/.github/workflows/auto-release-v13.yml
+++ b/.github/workflows/auto-release-v13.yml
@@ -1,9 +1,9 @@
-name: Auto Release on Version Bump
+name: Auto Release v13 on Version Bump
 
 on:
   push:
     branches:
-      - main
+      - release/v13
     paths:
       - "module.json"
       - "package.json"
@@ -60,17 +60,17 @@ jobs:
             exit 1
           fi
 
-          # main publishes the legacy Foundry v13 track (1.x / compat 13.x).
+          # release/v13 publishes the legacy Foundry v13 track (1.x / compat 13.x).
           # A v14-shaped commit landing here and auto-publishing under a v13
           # version string is exactly the incident that broke v13 users
           # previously — refuse instead of repeating it.
           if [[ "$VERSION" != 1.* ]]; then
-            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 1.x (v13) family expected on main."
-            echo "   If this is intentionally a v14 release, it belongs on the release/v14 branch, not main."
+            echo "❌ Refusing to publish: module.json version '$VERSION' is not in the 1.x (v13) family expected on release/v13."
+            echo "   If this is intentionally a v14 release, it belongs on main, not release/v13."
             exit 1
           fi
           if [[ "$COMPAT_MIN" != 13.* ]]; then
-            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 13.x range expected on main."
+            echo "❌ Refusing to publish: compatibility.minimum '$COMPAT_MIN' is not in the 13.x range expected on release/v13."
             exit 1
           fi
           echo "✅ Version $VERSION / compatibility.minimum $COMPAT_MIN match the v13 track."
@@ -137,7 +137,7 @@ jobs:
           TAG: ${{ steps.get_version.outputs.TAG }}
         run: |
           # Point manifest at the moving "v13-latest" tag, not GitHub's built-in
-          # "releases/latest" — now that a second stable track (release/v14)
+          # "releases/latest" — now that a second stable track (main, v14)
           # also publishes non-prerelease GitHub releases to this same repo,
           # "releases/latest" would flip between the v13 and v14 tracks
           # depending on which published most recently, silently pointing a


### PR DESCRIPTION
## What

`release/v13` was snapshotted from the pre-inversion `main`, so it inherited
`auto-release.yml` still triggering on pushes to `main`. GitHub evaluates workflows from
the ref being pushed, so version bumps on `release/v13` currently publish **nothing**.

This replaces that file with `main`'s reviewed `auto-release-v13.yml` verbatim:

- `on.push.branches: release/v13`
- guards `1.x` / compat `13.x`
- owns the moving `v13-latest` tag
- `make_latest: true` — keeps GitHub's repo-wide `/releases/latest` on the v13 track for
  legacy installs

`auto-release-v14.yml` and `beta-release.yml` are intentionally left in place: they trigger
on `main` and `staging`, so they can never fire from this branch. Removing them is optional
cleanup.

## Safety

`module.json` and `package.json` are untouched, so merging this publishes nothing. The
next intentional `1.x` bump on `release/v13` will be the first v13 release under the
inverted model — and the first one to create the `v13-latest` tag.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the v13 stable-release workflow and retargets version-bump releases from `main` to `release/v13`.
- Preserves the existing `1.x` and Foundry `13.x` guards.
- Keeps ownership of `v13-latest` and the repository-wide latest release on the v13 track.
- Leaves the operational release documentation referring to the previous branch and workflow filename.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow change appears safe to merge, with a non-blocking documentation update needed to prevent maintainers from following the obsolete v13 release path.

The workflow consistently targets the v13 branch and retains its version, compatibility, and tag guards; the remaining issue is that repository release instructions still identify `main` and the removed `auto-release.yml` filename.

**Files Needing Attention:** .github/workflows/auto-release-v13.yml and .github/RELEASE_WORKFLOW.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-release-v13.yml | Correctly retargets the guarded v13 release workflow to `release/v13`, but the renamed workflow and branch are not reflected in the release instructions. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fauto-release-v13.yml%3A1-6%0A**Release%20instructions%20remain%20outdated**%0A%0AThe%20renamed%20workflow%20now%20runs%20only%20on%20%60release%2Fv13%60%2C%20but%20%60.github%2FRELEASE_WORKFLOW.md%60%20still%20directs%20maintainers%20to%20use%20%60main%60%20and%20%60.github%2Fworkflows%2Fauto-release.yml%60%2C%20increasing%20the%20practical%20risk%20of%20preparing%20a%20v13%20release%20on%20the%20wrong%20branch%20or%20troubleshooting%20a%20file%20that%20no%20longer%20exists.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=53&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fauto-release-v13.yml%3A1-6%0A**Release%20instructions%20remain%20outdated**%0A%0AThe%20renamed%20workflow%20now%20runs%20only%20on%20%60release%2Fv13%60%2C%20but%20%60.github%2FRELEASE_WORKFLOW.md%60%20still%20directs%20maintainers%20to%20use%20%60main%60%20and%20%60.github%2Fworkflows%2Fauto-release.yml%60%2C%20increasing%20the%20practical%20risk%20of%20preparing%20a%20v13%20release%20on%20the%20wrong%20branch%20or%20troubleshooting%20a%20file%20that%20no%20longer%20exists.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=camrun91%2Farchivist-sync&pr=53&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/auto-release-v13.yml:1-6
**Release instructions remain outdated**

The renamed workflow now runs only on `release/v13`, but `.github/RELEASE_WORKFLOW.md` still directs maintainers to use `main` and `.github/workflows/auto-release.yml`, increasing the practical risk of preparing a v13 release on the wrong branch or troubleshooting a file that no longer exists.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: wire the v13 stable release workflow..."](https://github.com/camrun91/archivist-sync/commit/8c96ce87dee35dffc9816f6249b19409c69efc96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50441648)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->