### PR TITLE
fix: filter related quests by ownership (Greptile F1)

### DIFF
--- a/scripts/modules/sheets/page-sheet-v2.js
+++ b/scripts/modules/sheets/page-sheet-v2.js
@@ -727,20 +727,22 @@ class ArchivistBasePageSheetV2 extends V2.HandlebarsApplicationMixin(
           String(r.entityId) === archivistId
       )
     );
+    const visibleMatches = matches.filter((q) => {
+      const questJournal = this._findPageOrEntryByArchivistId(String(q.id));
+      if (!questJournal) return true;
+      const doc =
+        questJournal.documentName === 'JournalEntryPage'
+          ? questJournal.parent
+          : questJournal;
+      return canSee(doc);
+    });
     grid.innerHTML = '';
-    if (!matches.length) {
+    if (!visibleMatches.length) {
       grid.innerHTML = '<span class="quest-empty-state">None</span>';
       return;
     }
-    for (const q of matches) {
+    for (const q of visibleMatches) {
       const questJournal = this._findPageOrEntryByArchivistId(String(q.id));
-      if (questJournal) {
-        const doc =
-          questJournal.documentName === 'JournalEntryPage'
-            ? questJournal.parent
-            : questJournal;
-        if (!canSee(doc)) continue;
-      }
       const name = q.questName || 'Quest';
       const card = document.createElement('div');
       card.className = 'archivist-card';
@@ -763,7 +765,8 @@ class ArchivistBasePageSheetV2 extends V2.HandlebarsApplicationMixin(
     if (nav) {
       const base = nav.dataset._label || nav.textContent || 'Quests';
       if (!nav.dataset._label) nav.dataset._label = base;
-      nav.textContent = matches.length > 0 ? `${base} (${matches.length})` : base;
+      nav.textContent =
+        visibleMatches.length > 0 ? `${base} (${visibleMatches.length})` : base;
     }
   }
 


### PR DESCRIPTION
## Summary
- Compute `visibleMatches` with the `canSee` ownership gate in `_renderRelatedQuests`
- Use `visibleMatches` consistently for empty state, card rendering, and Quests tab badge count

Fixes the partial Greptile F1 leak where hidden quests still inflated the tab count and could leave a non-empty grid when all matches were ownership-filtered.

## Test plan
- [ ] Open a character/faction/location/item sheet as a non-GM player with hide-by-ownership enabled
- [ ] Confirm Quests tab shows correct count and empty state when linked quests are not observable
- [ ] Confirm GMs still see all related quests

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes ownership filtering for related quests so card rendering, empty-state selection, and badge counts use the same collection.
- Adds a `visibleMatches` collection based on the existing `canSee` gate.
- Uses `visibleMatches` for the empty state, quest-card loop, and Quests tab count.
- The new filter still fails open when a quest has no resolvable local ownership document.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until unresolved quest documents fail closed under hide-by-ownership, since the current branch still exposes quest metadata to non-GM users.

The new authoritative visibleMatches filter bypasses canSee whenever local quest lookup fails, allowing API-provided quest names, IDs, cards, and counts to remain visible without an OBSERVED permission check.

**Files Needing Attention:** scripts/modules/sheets/page-sheet-v2.js
</details>

<details open><summary><h3>Security Review</h3></summary>

A non-GM can still see a related quest's name, ID, existence, and badge contribution when its local Journal document cannot be resolved, because the ownership filter explicitly retains that quest without checking permission. **How this was verified:** The unresolved-document branch returns true before `canSee`, after which the API-provided quest metadata is rendered and counted.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/modules/sheets/page-sheet-v2.js | Centralizes related-quest ownership filtering, but unresolved quest documents remain visible without an affirmative permission check. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fmodules%2Fsheets%2Fpage-sheet-v2.js%3A732%0A**Unresolved%20quests%20bypass%20ownership%20filtering**%0A%0AWhen%20a%20non-GM%20uses%20hide-by-ownership%20and%20a%20related%20quest%20has%20no%20resolvable%20local%20Journal%20document%2C%20this%20branch%20retains%20the%20quest%20without%20an%20%60OBSERVED%60%20permission%20check%2C%20exposing%20its%20name%2C%20ID%2C%20existence%2C%20and%20badge%20contribution.%20**How%20this%20was%20verified%3A**%20The%20unresolved-document%20branch%20returns%20true%20before%20%60canSee%60%2C%20after%20which%20the%20API-provided%20quest%20metadata%20is%20rendered%20and%20counted.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!questJournal%29%20return%20!hideByOwnership%20%7C%7C%20game.user%3F.isGM%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fmodules%2Fsheets%2Fpage-sheet-v2.js%3A732%0A**Unresolved%20quests%20bypass%20ownership%20filtering**%0A%0AWhen%20a%20non-GM%20uses%20hide-by-ownership%20and%20a%20related%20quest%20has%20no%20resolvable%20local%20Journal%20document%2C%20this%20branch%20retains%20the%20quest%20without%20an%20%60OBSERVED%60%20permission%20check%2C%20exposing%20its%20name%2C%20ID%2C%20existence%2C%20and%20badge%20contribution.%20**How%20this%20was%20verified%3A**%20The%20unresolved-document%20branch%20returns%20true%20before%20%60canSee%60%2C%20after%20which%20the%20API-provided%20quest%20metadata%20is%20rendered%20and%20counted.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!questJournal%29%20return%20!hideByOwnership%20%7C%7C%20game.user%3F.isGM%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=camrun91%2Farchivist-sync&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/modules/sheets/page-sheet-v2.js:732
**Unresolved quests bypass ownership filtering**

When a non-GM uses hide-by-ownership and a related quest has no resolvable local Journal document, this branch retains the quest without an `OBSERVED` permission check, exposing its name, ID, existence, and badge contribution. **How this was verified:** The unresolved-document branch returns true before `canSee`, after which the API-provided quest metadata is rendered and counted.

```suggestion
      if (!questJournal) return !hideByOwnership || game.user?.isGM;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: filter related quests by ownership ..."](https://github.com/camrun91/archivist-sync/commit/0b9ccf06f512388d4396382d73b9f801c1277403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50461092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->